### PR TITLE
chore: upstream=6.4.0,add=alpine_3.24,debian_forky,ubuntu_questing,drop=debian_bookworm

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,23 @@
+# bradfordwagner.ansible-role-azure-blob-cli
+
+## Updating the version
+
+Version is controlled by `abc_ver` in `defaults/main.yml`.
+
+Check for the latest release at: https://github.com/bradfordwagner/go-azure-blob-cli/releases
+
+```yaml
+abc_ver: X.Y.Z
+```
+
+After bumping the version, add a new checksums entry to `abc_checksums` in `defaults/main.yml`.
+Download the checksums file from:
+
+```
+https://github.com/bradfordwagner/go-azure-blob-cli/releases/download/X.Y.Z/checksums.txt
+```
+
+The `dl-checksums.sh` script automates generating the YAML block for a given version.
+
+Note: releases v1.2.0+ use lowercase platform names (`linux_amd64`, `darwin_arm64`, etc.).
+Also update `test.yml` to set `abc_ver` to the new version.

--- a/config.yaml
+++ b/config.yaml
@@ -9,22 +9,26 @@ builds:
       archs:
         - linux/amd64
         - linux/arm64
+    - os: alpine_3.24
+      archs:
+        - linux/amd64
+        - linux/arm64
     - os: archlinux_latest
       archs:
         - linux/amd64
-    - os: debian_bookworm
-      archs:
-        - linux/amd64
-        - linux/arm64
-    - os: debian_bookworm-slim
-      archs:
-        - linux/amd64
-        - linux/arm64
     - os: debian_trixie
       archs:
         - linux/amd64
         - linux/arm64
     - os: debian_trixie-slim
+      archs:
+        - linux/amd64
+        - linux/arm64
+    - os: debian_forky
+      archs:
+        - linux/amd64
+        - linux/arm64
+    - os: debian_forky-slim
       archs:
         - linux/amd64
         - linux/arm64
@@ -36,6 +40,10 @@ builds:
       archs:
         - linux/amd64
         - linux/arm64
+    - os: ubuntu_questing
+      archs:
+        - linux/amd64
+        - linux/arm64
 upstream:
     repo: ghcr.io/bradfordwagner/ansible
-    tag: 6.3.1
+    tag: 6.4.0

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,14 +1,24 @@
 ---
 # defaults file for azure-blob-cli
-abc_ver: 1.0.1
+abc_ver: 1.3.1
 abc_parent_install_dir: /usr/local
 abc_mirror: https://github.com/bradfordwagner/go-azure-blob-cli/releases/download
 
 abc_ansible_arch_to_download_arch:
-  x86_64: x86_64
+  x86_64: amd64
   aarch64: arm64
 
 abc_checksums:
+  # https://github.com/bradfordwagner/go-azure-blob-cli/releases/download/1.3.1/checksums.txt
+  1.3.1:
+    # https://github.com/bradfordwagner/go-azure-blob-cli/releases/download/1.3.1/go-azure-blob-cli_1.3.1_darwin_amd64.tar.gz
+    darwin_amd64: sha256:5080f646ff5e508670910740606716edab32f5a13754b58098c908b54cade960
+    # https://github.com/bradfordwagner/go-azure-blob-cli/releases/download/1.3.1/go-azure-blob-cli_1.3.1_darwin_arm64.tar.gz
+    darwin_arm64: sha256:622493063ab4c256292b227910ed967f51df60e9feee1010357337545fb04d3a
+    # https://github.com/bradfordwagner/go-azure-blob-cli/releases/download/1.3.1/go-azure-blob-cli_1.3.1_linux_amd64.tar.gz
+    linux_amd64: sha256:4687f692f22e5d4ee22f33b05ccc8064b92012e9df298d19eb59390ce3f65e9a
+    # https://github.com/bradfordwagner/go-azure-blob-cli/releases/download/1.3.1/go-azure-blob-cli_1.3.1_linux_arm64.tar.gz
+    linux_arm64: sha256:9fb8a08c1ba58449230f885aa2c9a09fca40049b8b1d928953cc7f14a2a132ba
   # https://github.com/bradfordwagner/go-azure-blob-cli/releases/download/1.1.0/checksums.txt
   1.1.0:
     # https://github.com/bradfordwagner/go-azure-blob-cli/releases/download/1.1.0/go-azure-blob-cli_1.1.0_Darwin_arm64.tar.gz

--- a/test.yml
+++ b/test.yml
@@ -2,7 +2,7 @@
 - hosts: localhost
   roles:
     - role: '{{ playbook_dir }}'
-      abc_ver: 1.0.1
+      abc_ver: 1.3.1
   tasks:
     - command: /usr/local/bin/abc
       register: abc_test_output

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,6 +1,6 @@
 ---
 # vars file for azure-blob-cli
-abc_platform: '{{ ansible_system }}_{{ abc_ansible_arch_to_download_arch[ansible_architecture] }}'
+abc_platform: '{{ ansible_system | lower }}_{{ abc_ansible_arch_to_download_arch[ansible_architecture] }}'
 abc_tgz: abc_{{ abc_ver }}_{{ abc_platform }}.tar.gz
 abc_tmp_tgz: /tmp/{{ abc_tgz }}
 abc_url: '{{ abc_mirror }}/{{ abc_ver }}/go-azure-blob-cli_{{ abc_ver }}_{{ abc_platform }}.tar.gz'


### PR DESCRIPTION
## Summary
- Bump ansible upstream tag 6.3.1 -> 6.4.0
- Add alpine_3.24, debian_forky, debian_forky-slim, ubuntu_questing
- Drop debian_bookworm, debian_bookworm-slim (Python 3.11 incompatible with Ansible 14)